### PR TITLE
Add flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+exclude = .git,__pycache__,docs,build,dist


### PR DESCRIPTION
This PR adds a .flake8 configuration file to enforce project linting standards: max-line-length of 100 characters, ignore E203 and W503, and exclude common directories.